### PR TITLE
gaby

### DIFF
--- a/callibration/run_callibration_exact.py
+++ b/callibration/run_callibration_exact.py
@@ -1,6 +1,32 @@
 import numpy as np
 import scipy as sp
+import json
+from collections import Counter
+import math
+from scipy.stats import chi2
+import os
 
+def convert_primes_to_binary_without_last_bit(filepath):
+    """
+    Lee primos desde un archivo (uno por línea),
+    los convierte a binario de ancho fijo w = ceil(L * log2(10)),
+    elimina el LSB (último bit), y concatena todos los resultados en un único bitstream.
+    """
+    with open(filepath, "r") as f:
+        lines = [line.strip() for line in f if line.strip().isdigit()]
+
+    if not lines:
+        return ""
+
+    L = len(lines[0])  # número de cifras decimales del primer primo
+    w = math.ceil(L * math.log2(10))  # ancho fijo recomendado por NIST
+
+    stream = []
+    for p in lines:
+        b = format(int(p), f'0{w}b')  # binario de longitud fija
+        stream.append(b[:-1])         # eliminar el LSB
+
+    return ''.join(stream)
 
 def aproximate_entropy_params(primes_sample):
     return 0
@@ -12,66 +38,111 @@ def excursion_params(primes_sample):
     return 0
 def excursions_variant_params(primes_sample):
     return 0
-def frequency_params(primes_sample):
-    return 0
+
+
+
+def frequency_params(filepath, json_path="monobit_calibration_P5.json", block_sizes=[50, 100, 200, 400]):
+    binaries = convert_primes_to_binary_without_last_bit(filepath)
+    bitstream = [int(bit) for b in binaries for bit in b]
+    n_bits = len(bitstream)
+
+    results = {}
+
+    for B in block_sizes:
+        N = n_bits // B
+        if N < 100:
+            continue
+
+        chisq = 0
+        for j in range(N):
+            block = bitstream[j*B : (j+1)*B]
+            pi_j = sum(block) / B
+            chisq += (pi_j - 0.5)**2
+
+        chisq_stat = 4 * B * chisq
+        p_value = chi2.sf(chisq_stat, df=N)
+
+        results[str(B)] = {
+            "N_blocks": int(N),
+            "chi2_stat": float(chisq_stat),
+            "p_value": float(p_value)
+        }
+
+    # Guardar resultados en JSON
+    if os.path.exists(json_path):
+        with open(json_path, "r") as f:
+            try:
+                calib = json.load(f)
+            except json.JSONDecodeError:
+                calib = {}
+    else:
+        calib = {}
+
+    calib["BlockFrequencyTest"] = {
+        "total_bits": n_bits,
+        "block_results": results,
+        "block_sizes_tested": list(results.keys())  # sólo informativo
+    }
+
+    with open(json_path, "w") as f:
+        json.dump(calib, f, indent=4)
+
+    return calib["BlockFrequencyTest"]
+
 def linear_complexity_params(primes_sample):
     return 0
 def longest_run_params(primes_sample):
     return 0
 def maurer_params(primes_sample):
     return 0
+
+import json
 from collections import Counter
-import numpy as np
 
-def monobit_params(primes_sample):
+def monobit_params(primes_sample, output_file="monobit_calibration.json"):
     """
-    Calcula los parámetros del Monobit Test (sin Benford):
-    - Primer dígito + intermedios → distribución uniforme.
-    - Último dígito → Dirichlet (dígitos 1,3,7,9).
-    Devuelve un diccionario JSON con estadísticas clave.
+    Calibrates digit distributions from a reference sample of primes.
+    Returns position-wise distributions and saves to JSON.
     """
+    count_first = Counter()
+    count_mid = Counter()
+    count_last = Counter()
+    total_first = total_mid = total_last = 0
 
-    # === Modelos teóricos internos ===
-    def p_mid(d):
-        return 0.1
-
-    def p_last(d):
-        return 0.25 if d in {1, 3, 7, 9} else 0
-
-    # === Conteo observado ===
-    observed_counts = Counter()
     for p in primes_sample:
-        digits = list(map(int, p))
-        for d in digits[0:4]:                # primer + intermedios
-            observed_counts[d] += 1
-        observed_counts[digits[4]] += 1      # último dígito
+        p_str = str(p).strip()
+        if not p_str.isdigit() or len(p_str) < 3:
+            continue
 
-    # === Conteo esperado ===
-    N = len(primes_sample)
-    expected_counts = {}
-    for d in range(10):
-        expected_counts[d] = (
-            N * 4 * p_mid(d) +
-            N * p_last(d)
-        )
+        first_digit = int(p_str[0])
+        last_digit = int(p_str[-1])
+        mid_digits = [int(ch) for ch in p_str[1:-1]]
 
-    # === Estadístico chi² ===
-    chi2 = 0
-    for d in range(10):
-        E = expected_counts[d]
-        O = observed_counts[d]
-        if E > 0:
-            chi2 += (O - E) ** 2 / E
+        count_first[first_digit] += 1
+        count_last[last_digit] += 1
+        total_first += 1
+        total_last += 1
 
-    return {
-        "test_name": "Monobit Test (Uniform + Dirichlet)",
-        "num_primes": N,
-        "total_digits": N * 5,
-        "observed_counts": dict(observed_counts),
-        "expected_counts": {str(k): round(v, 2) for k, v in expected_counts.items()},
-        "chi_squared_stat": round(chi2, 4),
-        "note": "Model assumes uniform distribution for first 4 digits and Dirichlet for last digit."
+        for d in mid_digits:
+            count_mid[d] += 1
+            total_mid += 1
+
+    # Convert to probability distributions
+    P_first = {str(d): count_first[d] / total_first for d in range(10)}
+    P_mid = {str(d): count_mid[d] / total_mid for d in range(10)}
+    P_last = {str(d): count_last[d] / total_last for d in range(10)}
+
+    calibration = {
+        "P_first": P_first,
+        "P_mid": P_mid,
+        "P_last": P_last
     }
+
+    with open(output_file, "w") as f:
+        json.dump(calibration, f, indent=4)
+
+    return calibration
+
 
 def non_overlap_matching_params(primes_sample):
     return 0


### PR DESCRIPTION
## Summary by Sourcery

Add full implementations for the frequency and monobit calibration tests on prime samples, including a binary‐conversion utility and JSON persistence of results.

New Features:
- Introduce convert_primes_to_binary_without_last_bit to read primes, convert to fixed-width binaries without the LSB, and concatenate into a bitstream.
- Implement frequency_params to perform block frequency tests over multiple block sizes, compute chi-square statistics and p-values, and write results to a JSON calibration file.
- Implement monobit_params to calibrate first, middle, and last digit distributions from a prime sample, output probability distributions, and save them to JSON.